### PR TITLE
集計部分の変更

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -25,6 +25,7 @@ export type UserState = {
   address: string;
   family: string;
   sex: 'male' | 'female' | 'None';
+  isAdmin: boolean;
 };
 export type logType = {
   createdAt: number;
@@ -216,6 +217,7 @@ const aggregate = (day: string) => {
       console.log("create DailyRanking");
       snapshot.forEach(doc => {
         const data = doc.data() as logType;
+        if(data.user.isAdmin){return}
         const currentAge = getAgeGroup(calcAge(data.user.birthday));
         const target = dailyRanking.find(logData => {
           return logData.documentID === data.documentID;
@@ -300,7 +302,7 @@ const aggregate = (day: string) => {
     });
 }
 
-exports.onSystemDeleted = functions.fireStore.document(productionSystemIndex + "/{testId}").onDelete((snap,context) => {
+exports.onSystemDeleted = functions.firestore.document(productionSystemIndex + "/{testId}").onDelete((snap,context) => {
   //const data = snap.data() as System;
   const filter = 'documentID:' + snap.id;
   index.deleteBy({filters: filter},((err,res) => {

--- a/src/user/components/detailList.tsx
+++ b/src/user/components/detailList.tsx
@@ -30,22 +30,25 @@ const DetailList: React.FC<{ documentId: string }> = (props) => {
     if (props.documentId !== detail.documentID) {
         isLoading = true
         detail.documentID = props.documentId    //無限ループ防止
-        fireStore.collection(systemIndex).doc(props.documentId).get().then(res => {
-            if (res.exists) {
-                const detailData = res.data() as System
-                updateDetail(detailData)
-                isLoading = false
-                detailData.totalView += 1;
-                detailData.dailyView += 1;
-                detailData.monthlyView += 1;
-                detailData.weeklyView[6]++;
-                fireStore.collection(systemIndex).doc(props.documentId).update(detailData).then(res=>console.log("view:",res)).catch(err => console.error(err))
+        if(!user.isAdmin){
+            fireStore.collection(systemIndex).doc(props.documentId).get().then(res => {
+                if (res.exists) {
+                    const detailData = res.data() as System
+                    updateDetail(detailData)
+                    isLoading = false
+                    detailData.totalView += 1;
+                    detailData.dailyView += 1;
+                    detailData.monthlyView += 1;
+                    detailData.weeklyView[6]++;
+                    fireStore.collection(systemIndex).doc(props.documentId).update(detailData).then(res=>console.log("view:",res)).catch(err => console.error(err))
+                }
             }
-        }).catch(err => console.error(err))
+            ).then(() => detailPageLogger(detail.documentID, user, detail))
+            .catch(err => console.error(err))
+        }
     }
 
     if (!isLoading && isSystemLoaded()) {   //等しいときはfetchなし
-        detailPageLogger(detail.documentID, user, detail)
         return (
             <div>
                 <div className="detail">

--- a/src/user/components/detailList.tsx
+++ b/src/user/components/detailList.tsx
@@ -27,28 +27,35 @@ const DetailList: React.FC<{ documentId: string }> = (props) => {
         }
     }
 
-    if (props.documentId !== detail.documentID) {
+    if (props.documentId !== detail.documentID) { //fetch
         isLoading = true
         detail.documentID = props.documentId    //無限ループ防止
-        if(!user.isAdmin){
-            fireStore.collection(systemIndex).doc(props.documentId).get().then(res => {
-                if (res.exists) {
-                    const detailData = res.data() as System
-                    updateDetail(detailData)
-                    isLoading = false
-                    detailData.totalView += 1;
-                    detailData.dailyView += 1;
-                    detailData.monthlyView += 1;
-                    detailData.weeklyView[6]++;
-                    fireStore.collection(systemIndex).doc(props.documentId).update(detailData).then(res=>console.log("view:",res)).catch(err => console.error(err))
-                }
-            }
-            ).then(() => detailPageLogger(detail.documentID, user, detail))
-            .catch(err => console.error(err))
-        }
+        fireStore.collection(systemIndex).doc(props.documentId).get().then(res => {
+            if (res.exists) {
+                const detailData = res.data() as System
+                updateDetail(detailData)
+                isLoading = false
+        }})
+        .catch(err => console.error(err))
     }
+    
 
     if (!isLoading && isSystemLoaded()) {   //等しいときはfetchなし
+        if(!user.isAdmin && (user.nickName !== '')){
+            console.log("Login user detected.")
+            detail.totalView += 1;
+            detail.dailyView += 1;
+            detail.monthlyView += 1;
+            detail.weeklyView[6]++;
+            fireStore.collection(systemIndex)
+                .doc(props.documentId)
+                .update(detail)
+                    .then(() => detailPageLogger(detail.documentID, user, detail))
+            .catch(err => console.error(err))
+        }else{
+            console.log("This user is not logged in")
+        }
+
         return (
             <div>
                 <div className="detail">


### PR DESCRIPTION
## 問題
閲覧数が0なのに70代に人気になっている制度があった

## 原因
+ AdminはdailyViewなどを増やさないにもかかわらず、毎日の集計でageGroupにadminも入っていた
+ search => detail とページ遷移したとき、logが保存されていなかった
    + 新しくfetchした場合のみロギングしていた模様

## 変更点
+ Adminなら集計しない
+ (!isAdmin && ログインユーザー) ならロギングする
